### PR TITLE
add dockerfile and compose file and github workflow to build it

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+PORT_NUMBER=8080
+GIT_TAG=main
+DOCKER_TAG=latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,15 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker-compose build

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ via File, Import, Maven, Existing Maven Projects.
 
 This builds against a released version of core-pv and jca. To use the "latest" build from locally compiled versions of for example https://github.com/epics-base/jca.git and https://github.com/ControlSystemStudio/phoebus/tree/master/core/pva, `mvn clean install` these, then update the pom.xml to list their 1.2.3-SNAPSHOT versions, which should use the binaries that you just installed locally.
 
+**Docker**
+
+Edit .env file with settings for git version and port number and docker/setenv.sh with your local site settings for EPICS/web socket settings. Then:
+
+```
+docker-compose build
+```
 
 PV Types
 --------
@@ -96,6 +103,18 @@ the web socket and any applications that utilize it (Display Builder Web Runtime
 behind an authentication layer (Web Proxy, ...) which will limit access
 to appropriate users.
 
+**Docker**
+
+To run docker container (use -d option to run in detached mode):
+
+```
+docker-compose up
+```
+
+The status can be seen with docker ps. The status will be healthy if pvws is fully connected
+```
+docker ps
+```
 
 Client URLs
 -----------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+    pvws:
+        build:
+            context: docker
+            args:
+                GIT_TAG: ${GIT_TAG}
+                PORT_NUMBER: ${PORT_NUMBER}
+        image: pvws:${DOCKER_TAG}
+        container_name: pvws 
+        network_mode: "host"
+        healthcheck:
+            test: curl -sS http://localhost:${PORT_NUMBER}/pvws/ | grep -c "img/connected.png" > /dev/null
+            timeout: "5s"
+            retries: 10

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine/git:latest as source_fetch
+
+RUN git clone https://github.com/ornl-epics/pvws.git /pvws
+ARG GIT_TAG=main
+RUN cd /pvws && git checkout ${GIT_TAG}
+
+FROM maven:3.8.7-eclipse-temurin-17 as maven_builder
+
+COPY --from=source_fetch /pvws /pvws
+RUN cd /pvws && mvn clean package 
+
+FROM tomcat:9.0-jdk17
+
+ARG PORT_NUMBER=8080
+COPY --from=maven_builder /pvws/target/pvws.war ${CATALINA_HOME}/webapps
+COPY ./setenv.sh ${CATALINA_HOME}/bin
+RUN sed -i.bak -e "s|Connector port=\"8080\"|Connector port=\"${PORT_NUMBER}\"|g" \
+  -e 's|Server port="8005" shutdown="SHUTDOWN"|Server port="-1" shutdown="SHUTDOWN"|g' \
+   ${CATALINA_HOME}/conf/server.xml

--- a/docker/setenv.sh
+++ b/docker/setenv.sh
@@ -1,0 +1,15 @@
+# Web Socket Settings
+#export PV_DEFAULT_TYPE=ca
+#export PV_THROTTLE_MS=1000
+#export PV_ARRAY_THROTTLE_MS=10000
+#export PV_WRITE_SUPPORT=false
+
+# Channel Access Settings
+#export EPICS_CA_ADDR_LIST=localhost
+#export EPICS_CA_MAX_ARRAY_BYTES=1000000
+
+# PV Access Settings
+#export EPICS_PVA_ADDR_LIST=localhost
+#export EPICS_PVA_AUTO_ADDR_LIST=YES
+#export EPICS_PVA_BROADCAST_PORT=5076
+#export EPICS_PVA_NAME_SERVERS=


### PR DESCRIPTION
Hi @kasemir ,

This was discussed at the code-a-thon in October to add a dockerfile to PVWS and DBWR but it's taken awhile for me to get around to it.

It's unclear to me which OS is the best for community level docker images so I decided to punt on that and just use the official maven and tomcat images and go with whatever OS they use in those. Also added a github CI workflow to build the image. If this works I can also do a similar PR for DBWR