### PR TITLE
Add support for b64flt, b64byt and b64srt

### DIFF
--- a/src/main/webapp/js/pvws.js
+++ b/src/main/webapp/js/pvws.js
@@ -103,6 +103,22 @@ class PVWS
                 // console.log(JSON.stringify(jm.value));
                 delete jm.b64dbl;
             }
+            else if (jm.b64flt !== undefined)
+            {
+                let bytes = toByteArray(jm.b64flt);
+                jm.value = new Float32Array(bytes.buffer);
+                // Convert to plain array
+                jm.value = Array.prototype.slice.call(jm.value);
+                delete jm.b64flt;
+            }
+            else if (jm.b64srt !== undefined)
+            {
+                let bytes = toByteArray(jm.b64srt);
+                jm.value = new Int16Array(bytes.buffer);
+                // Convert to plain array
+                jm.value = Array.prototype.slice.call(jm.value);
+                delete jm.b64srt;
+            }
             else if (jm.b64int !== undefined)
             {
                 let bytes = toByteArray(jm.b64int);
@@ -110,6 +126,14 @@ class PVWS
                 // Convert to plain array, if necessary
                 jm.value = Array.prototype.slice.call(jm.value);
                 delete jm.b64int;
+            }
+            else if (jm.b64byt !== undefined)
+            {
+                let bytes = toByteArray(jm.b64byt);
+                jm.value = new Uint8Array(bytes.buffer);
+                // Convert to plain array, if necessary
+                jm.value = Array.prototype.slice.call(jm.value);
+                delete jm.b64byt;
             }
                 
             // Merge received data with last known value


### PR DESCRIPTION
As discussed in https://github.com/ornl-epics/pvws/issues/21 currently only b64int and b64dbl arrays are supported. I have added support for float arrays, short arrays and byte arrays in PVWS sent as b64flt, b64srt and b64byt.
In addition, PVWS was automatically handling all byte arrays as strings meaning that clients did not receive the original char array. I have updated PVWS to handle these as byte arrays and send as such. It is then up to the client to format this as a string if that format option is set. 