### PR TITLE
Update core-pv version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
-      <version>4.7.0</version>
+      <version>4.7.3</version>
     </dependency>
 
 <!-- To use a pre-release version of the latest core-pv and/or jca,


### PR DESCRIPTION
To run pvws under docker we came across an ipv6 issue that caused the container to crash. This has been mitigated by introducing an environment variable called EPICS_PVA_ENABLE_IPV6. If se to "NO", this then allows pvws container to run correctly. This environment wariable is available in core-pv 4.7.3