### PR TITLE
Add vtype to metadata of string PVs

### DIFF
--- a/src/main/java/pvws/ws/Vtype2Json.java
+++ b/src/main/java/pvws/ws/Vtype2Json.java
@@ -113,10 +113,20 @@ public class Vtype2Json
     private static void handleString(final JsonGenerator g, final VString value, final VType last_value) throws Exception
     {
         final AlarmSeverity severity = value.getAlarm().getSeverity();
-        if (last_value == null  ||
-            (last_value instanceof VString  &&
-             ((VString) last_value).getAlarm().getSeverity() != severity))
-            g.writeStringField("severity", value.getAlarm().getSeverity().name());
+        if (last_value == null)
+        {
+            // Initially, add complete metadata
+            g.writeStringField("vtype", VType.typeOf(value).getSimpleName());
+            // Initial severity
+            g.writeStringField("severity", severity.name());
+        }
+        else
+        {
+            // Add severity if it changed
+            if ((last_value instanceof VString) &&
+                 ((VString) last_value).getAlarm().getSeverity() != severity)
+                g.writeStringField("severity", severity.name());
+        }
 
         g.writeStringField("text", value.getValue());
     }


### PR DESCRIPTION
Other value handling methods in Vtype2Json.java file include "vtype" field in metadata initially, but handleString() method does not and "vtype" field does not show up in WebSockset response for stringin/stringout records. I am not certain whether this is the implementation by design or not. If not, this PR is to make handleString() be consistent with other handling methods.