### PR TITLE
Adjust readonly field generation logic

### DIFF
--- a/src/main/java/pvws/ws/Vtype2Json.java
+++ b/src/main/java/pvws/ws/Vtype2Json.java
@@ -56,7 +56,7 @@ public class Vtype2Json
      *  @return JSON text
      *  @throws Exception on error
      */
-    public static String toJson(final String name, final VType value, final VType last_value, final boolean last_readonly, final boolean readonly) throws Exception
+    public static String toJson(final String name, final VType value, final VType last_value, final Boolean last_readonly, final Boolean readonly) throws Exception
     {
         final ByteArrayOutputStream buf = new ByteArrayOutputStream();
         final JsonGenerator g = json_factory.createGenerator(buf);
@@ -94,7 +94,7 @@ public class Vtype2Json
         // null: Neither 'value' nor 'text'
 
         // Change in read/write access?
-        if (last_readonly != readonly)
+        if (last_readonly == null || !last_readonly.equals(readonly))
             g.writeBooleanField("readonly", readonly);
 
         final Time time = Time.timeOf(value);

--- a/src/main/java/pvws/ws/WebSocket.java
+++ b/src/main/java/pvws/ws/WebSocket.java
@@ -403,7 +403,7 @@ public class WebSocket
      *  @param last_readonly Was the PV read-only?
      *  @param readonly Is the PV read-only?
      */
-    public void sendUpdate(final String name, final VType value, final VType last_value, final boolean last_readonly, final boolean readonly)
+    public void sendUpdate(final String name, final VType value, final VType last_value, final Boolean last_readonly, final Boolean readonly)
     {
         try
         {

--- a/src/main/java/pvws/ws/WebSocketPV.java
+++ b/src/main/java/pvws/ws/WebSocketPV.java
@@ -44,7 +44,7 @@ public class WebSocketPV
                                         subscription_access = new AtomicReference<>();
     private volatile boolean subscribed_for_array = false;
     private volatile VType last_value = null;
-    private volatile boolean last_readonly = true;
+    private volatile Boolean last_readonly = null;
 
     static
     {

--- a/src/main/java/pvws/ws/WebSocketPV.java
+++ b/src/main/java/pvws/ws/WebSocketPV.java
@@ -134,9 +134,10 @@ public class WebSocketPV
             }
         }
 
-        socket.sendUpdate(name, value, last_value, last_readonly, pv.isReadonly() || !PV_WRITE_SUPPORT);
+        Boolean current_readonly = pv.isReadonly() || !PV_WRITE_SUPPORT;
+        socket.sendUpdate(name, value, last_value, last_readonly, current_readonly);
         last_value = value;
-        last_readonly = pv.isReadonly();
+        last_readonly = current_readonly;
     }
 
     /** Handle change in access permissions
@@ -144,8 +145,9 @@ public class WebSocketPV
      */
     private void handleAccessChanges(final Boolean readonly)
     {
-        socket.sendUpdate(name, last_value, last_value, last_readonly, pv.isReadonly() || !PV_WRITE_SUPPORT);
-        last_readonly = pv.isReadonly();
+        Boolean current_readonly = pv.isReadonly() || !PV_WRITE_SUPPORT;
+        socket.sendUpdate(name, last_value, last_value, last_readonly, current_readonly);
+        last_readonly = current_readonly;
     }
 
     /** @return Most recent value or null */


### PR DESCRIPTION
1. Use nullable Boolean class instead of primitive boolean for last_readonly and readonly, so that the first value does not equal to null and "readonly" field can show up in WebSocket response.
2. Ensure both last_readonly and readonly are the OR logic of isReadonly() and !PV_WRITE_SUPPORT, because they will be compared in toJson() method.