### PR TITLE
Hopefully fix docker github CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build the Docker image
-      run: docker-compose build
+      run: docker compose build


### PR DESCRIPTION
I believe the newer version of ubuntu in github actions has updated the docker engine and now the correct command is `docker compose` instead of `docker-compose`

https://stackoverflow.com/questions/66514436/difference-between-docker-compose-and-docker-compose