### PR TITLE
Add link to simulated channels documentation in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The PV web socket supports the PV names handled by core-pv, which include:
 
  * `ca://NameOfPV` for Channel Access
  * `pva://NameOfPV` for PV Access
- * `sim://NameOfPV` for simulated channels that may be useful for testing
+ * `sim://NameOfPV` for [simulated channels](https://control-system-studio.readthedocs.io/en/latest/core/pv/doc/index.html#simulated) that may be useful for testing
  * `NameOfPV` uses the default PV type, see `PV_DEFAULT_TYPE` below
  
 


### PR DESCRIPTION
as someone who has used PVWS but not phoebus I wasn't sure where to find a list of the supported simulated channels - this adds a link to the readme to where they are documented. 